### PR TITLE
Upgrade to Filament v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3]
+        php: [8.4]
         laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,15 +22,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
     
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Filament Pennant (`creativitykills/filament-pennant`) is a Laravel package that integrates Laravel Pennant feature flags into the Filament Admin Panel. It provides a UI for managing class-based feature flags with scoped segments (e.g., enabling a feature for specific users or teams).
+
+## Common Commands
+
+```bash
+composer test                # Run Pest test suite
+composer test-coverage       # Run tests with coverage report
+composer analyse             # Run PHPStan static analysis (level 5)
+composer format              # Format code with Laravel Pint
+vendor/bin/pest --filter="test name"  # Run a single test
+```
+
+## Architecture
+
+**Namespace:** `CK\FilamentPennant\`
+
+### Entry Points
+- **FilamentPennantServiceProvider** — Package bootstrap via Spatie's PackageServiceProvider. Registers config, migrations, and auto-discovers class-based features.
+- **FilamentPennantPlugin** — Filament Plugin interface implementation. Registers the FeatureSegmentResource with Filament panels and provides fluent configuration (authorization, navigation, labels).
+- **FilamentPennant facade** — Public API surface for schema customizations and model access.
+
+### Core Flow
+1. Feature classes (in `App\Features` or custom locations registered via `FilamentPennantServiceProvider::registerCustomFeatureLocations()`) use the `ResolvesFeatureSegments` trait
+2. The `FeatureSegment` model stores feature/scope/values combinations in the `featuresegments` table with a unique constraint on `[feature, scope, active]`
+3. `ResolvesFeatureSegments::resolve()` queries active segments to determine if a feature applies to a given scope, falling back to `resolveDefaultValue()` from config
+4. The Filament resource (`FeatureSegmentResource` + `ManageFeatureSegments` page) provides the admin UI for CRUD operations plus bulk activate/deactivate/purge actions
+
+### Traits (src/Concerns/)
+- **ResolvesFeatureSegments** — Used in feature classes; handles database-backed feature resolution
+- **ConfiguresFeatureSegmentResource** — Used by the Plugin; holds navigation/model configuration
+- **AllowsFeatureSegmentResourceSchemaCustomizations** — Used by the Facade; enables closure-based modifications to form fields, table columns, filters, and actions
+
+### Events
+All events implement `ShouldDispatchAfterCommit`. Dispatched for: segment create/update/delete, activate/deactivate for everyone, and purge. Each event carries the feature/segment data and the authenticated user.
+
+## Key Conventions
+
+- All files declare `strict_types=1`
+- Events use past tense naming (e.g., `FeatureSegmentCreated`)
+- Configuration drives feature-to-scope mappings — scopes are defined per-feature in `config/filament-pennant.php` under `feature-segment.segments`
+- The package supports Laravel 10/11/12 and PHP 8.3/8.4
+- Testing uses Pest with Orchestra Testbench (SQLite in-memory database)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.4",
         "filament/filament": "^4.0",
-        "illuminate/contracts": "^11.28||^12.0",
+        "illuminate/contracts": "^11.28||^12.0||^13.0",
         "laravel/pennant": "^1.17",
         "spatie/laravel-package-tools": "^1.16"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "filament/filament": "^4.0",
         "illuminate/contracts": "^11.28||^12.0",
         "laravel/pennant": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "filament/filament": "^4.0",
         "illuminate/contracts": "^11.28||^12.0",
         "laravel/pennant": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.4",
-        "filament/filament": "^3.3",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "filament/filament": "^4.0",
+        "illuminate/contracts": "^11.28||^12.0",
         "laravel/pennant": "^1.17",
         "spatie/laravel-package-tools": "^1.16"
     },
@@ -26,7 +26,7 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
+        "orchestra/testbench": "^10.0.0||^9.0.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,5 @@
+parameters:
+    ignoreErrors:
+        -
+            message: '#Trait CK\\FilamentPennant\\Concerns\\ResolvesFeatureSegments is used zero times and is not analysed\.#'
+            path: src/Concerns/ResolvesFeatureSegments.php

--- a/src/Concerns/AllowsFeatureSegmentResourceSchemaCustomizations.php
+++ b/src/Concerns/AllowsFeatureSegmentResourceSchemaCustomizations.php
@@ -44,7 +44,7 @@ trait AllowsFeatureSegmentResourceSchemaCustomizations
     }
 
     /**
-     * @param  array<\Filament\Forms\Components\Component>  $components
+     * @param  array<\Filament\Schemas\Components\Component>  $components
      */
     public static function featureSegmentFormComponents(array $components): array
     {
@@ -68,7 +68,7 @@ trait AllowsFeatureSegmentResourceSchemaCustomizations
     }
 
     /**
-     * @param  array<\Filament\Tables\Actions\Action>  $actions
+     * @param  array<\Filament\Actions\Action>  $actions
      */
     public static function featureSegmentTableActions(array $actions): array
     {
@@ -92,7 +92,7 @@ trait AllowsFeatureSegmentResourceSchemaCustomizations
     }
 
     /**
-     * @param  array<\Filament\Tables\Actions\Action|\Filament\Tables\Actions\ActionGroup>  $actions
+     * @param  array<\Filament\Actions\Action|\Filament\Actions\ActionGroup>  $actions
      */
     public static function featureSegmentTableHeaderActions(array $actions): array
     {

--- a/src/FilamentPennantServiceProvider.php
+++ b/src/FilamentPennantServiceProvider.php
@@ -40,10 +40,14 @@ class FilamentPennantServiceProvider extends PackageServiceProvider
 
     public function bootingPackage(): void
     {
-        Feature::discover();
+        if (is_dir($this->app->path('Features'))) {
+            Feature::discover();
+        }
 
         foreach (static::$customFeatureLocations as $namespace => $path) {
-            Feature::discover($namespace, $path);
+            if (is_dir($path)) {
+                Feature::discover($namespace, $path);
+            }
         }
     }
 }

--- a/src/Resources/FeatureSegmentResource.php
+++ b/src/Resources/FeatureSegmentResource.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace CK\FilamentPennant\Resources;
 
 use Filament\Tables;
-use Filament\Forms\Get;
-use Filament\Forms\Set;
-use Filament\Forms\Form;
+use Filament\Actions\EditAction;
+use Filament\Actions\DeleteAction;
+use Filament\Schemas\Schema;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Tables\Table;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Filament\Support\Colors\Color;
-use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Select;
 use Filament\Support\Enums\FontWeight;
 use Illuminate\Support\Facades\Config;
@@ -27,11 +28,11 @@ use CK\FilamentPennant\Events\FeatureSegmentDeleting;
 
 class FeatureSegmentResource extends Resource
 {
-    public static function form(Form $form): Form
+    public static function form(Schema $schema): Schema
     {
         $allFeatures = FilamentPennant::getFeatureSegmentModelInstance()->allFeatures();
 
-        $schema = FilamentPennant::featureSegmentFormComponents([
+        $components = FilamentPennant::featureSegmentFormComponents([
             Select::make('feature')
                 ->label(__('Select Feature'))
                 ->live()
@@ -66,7 +67,7 @@ class FeatureSegmentResource extends Resource
                 ->columnSpanFull(),
         ]);
 
-        return $form->schema($schema);
+        return $schema->components($components);
     }
 
     /**
@@ -159,10 +160,10 @@ class FeatureSegmentResource extends Resource
         ]);
 
         $actions = FilamentPennant::featureSegmentTableActions([
-            Tables\Actions\EditAction::make()
+            EditAction::make()
                 ->button()
                 ->after(fn ($record) => FeatureSegmentUpdated::dispatch($record, Filament::auth()->user())),
-            Tables\Actions\DeleteAction::make()
+            DeleteAction::make()
                 ->button()
                 ->successNotification(fn () => Notification::make()->success()->title(__('Segment deleted successfully')))
                 ->before(fn ($record) => FeatureSegmentDeleting::dispatch($record, Filament::auth()->user()))
@@ -173,7 +174,7 @@ class FeatureSegmentResource extends Resource
             ->columns($columns)
             ->defaultSort('feature')
             ->filters($filters)
-            ->actions($actions);
+            ->recordActions($actions);
     }
 
     public static function getPages(): array

--- a/src/Resources/ManageFeatureSegments.php
+++ b/src/Resources/ManageFeatureSegments.php
@@ -39,7 +39,7 @@ class ManageFeatureSegments extends ManageRecords
             Select::make('feature')
                 ->label(__('Feature'))
                 ->selectablePlaceholder(false)
-                ->options(array_merge([null => __('All Features')], $allFeaturesOptionsList))
+                ->options(array_merge(['' => __('All Features')], $allFeaturesOptionsList))
                 ->columnSpanFull(),
         ];
 
@@ -59,7 +59,7 @@ class ManageFeatureSegments extends ManageRecords
                     ->requiresConfirmation()
                     ->color('danger')
                     ->modalDescription(fn () => __('This will activate the selected feature for everyone.'))
-                    ->form($activateForEveryoneSchema)
+                    ->schema($activateForEveryoneSchema)
                     ->modalSubmitActionLabel(__('Activate'))
                     ->action(fn ($data) => $this->activateForAll($data['feature'])),
 
@@ -70,7 +70,7 @@ class ManageFeatureSegments extends ManageRecords
                     ->requiresConfirmation()
                     ->color('danger')
                     ->modalDescription(fn () => __('This will deactivate the selected feature for everyone.'))
-                    ->form($deactivateForEveryoneSchema)
+                    ->schema($deactivateForEveryoneSchema)
                     ->modalSubmitActionLabel(__('Deactivate'))
                     ->action(fn ($data) => $this->deactivateForAll($data['feature'])),
 
@@ -81,7 +81,7 @@ class ManageFeatureSegments extends ManageRecords
                     ->requiresConfirmation()
                     ->color('danger')
                     ->modalDescription(fn () => __('This action will purge resolved features from storage.'))
-                    ->form($purgeFeaturesSchema)
+                    ->schema($purgeFeaturesSchema)
                     ->modalSubmitActionLabel(__('Purge'))
                     ->color('danger')
                     ->action(fn ($data) => $this->purgeFeatures($data['feature'])),
@@ -126,6 +126,8 @@ class ManageFeatureSegments extends ManageRecords
 
     private function purgeFeatures(?string $feature): void
     {
+        $feature = $feature ?: null;
+
         Feature::purge($feature);
 
         $featureTitle = is_null($feature) ? __('All features') : $feature::title();


### PR DESCRIPTION
## Summary
- Upgrade `filament/filament` from `^3.3` to `^4.0`
- Drop Laravel 10 support (now requires `illuminate/contracts ^11.28||^12.0`)
- Migrate to Filament v4 APIs: `Form` → `Schema`, `Get`/`Set` utilities moved, table actions consolidated under `Filament\Actions`, deprecated `Table::actions()` → `recordActions()`, deprecated `Action::form()` → `schema()`
- Guard `Feature::discover()` with directory existence checks
- Remove Laravel 10 / Testbench 8 from CI matrix

## Test plan
- [x] `composer analyse` passes (0 actionable errors)
- [x] `composer test` passes (2 tests, 4 assertions)
- [x] Verify in a real Filament v4 panel that the feature segments resource loads and CRUD works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades major UI/admin dependencies (Filament v4) and adjusts resource/action APIs; regressions would surface in the Feature Segment admin UI and package compatibility matrix.
> 
> **Overview**
> Upgrades the package to **Filament v4** and tightens platform support by requiring PHP `^8.4` with `illuminate/contracts` `^11.28 || ^12`, while dropping Laravel 10/Testbench 8 from CI.
> 
> Migrates Filament resource code to v4 APIs: `Form` → `Schema` + new `Get`/`Set` utilities, table actions moved to `Filament\Actions` and applied via `recordActions()`, and modal action definitions switched from `form()` to `schema()` (including fixing “All Features” purge selection handling).
> 
> Hardens feature auto-discovery by only calling `Feature::discover()` for default/custom locations when the target directories exist, and adds a `phpstan-baseline.neon` to ignore an unused-trait analysis warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c6494d2666e6b9859269b375a0c8a090465bc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->